### PR TITLE
fixup! allow toggling presidential alerts

### DIFF
--- a/res/xml-v31/preferences.xml
+++ b/res/xml-v31/preferences.xml
@@ -45,7 +45,6 @@
 
         <!-- Show checkbox for Presidential alerts in settings -->
         <SwitchPreferenceCompat android:defaultValue="true"
-                          android:enabled="false"
                           android:key="enable_cmas_presidential_alerts"
                           android:summary="@string/enable_cmas_presidential_alerts_summary"
                           android:title="@string/enable_cmas_presidential_alerts_title"/>


### PR DESCRIPTION
The main toggle for emergency alerts had to be toggled to enable the presidential alerts toggle.